### PR TITLE
Dotenv configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,5 @@ cklist-*.tar
 # In case you use Node.js/npm, you want to ignore these.
 npm-debug.log
 /assets/node_modules/
-
+.env
+envs/

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -2,10 +2,6 @@ import Config
 
 # Configure your database
 config :cklist, Cklist.Repo,
-  username: "cklist",
-  password: "cklist",
-  hostname: "localhost",
-  database: "cklist_dev",
   stacktrace: true,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -37,114 +37,120 @@ if env!("PHX_SERVER", :boolean, false) do
   config :cklist, CklistWeb.Endpoint, server: true
 end
 
-if config_env() == :dev do
-  config :cklist, Cklist.Repo,
-    url: env!("DATABASE_URL", :string, "ecto://cklist:cklist@localhost/cklist_dev")
-end
+case config_env() do
+  :test ->
+    config :cklist, Cklist.Repo,
+      url:
+        env!("DATABASE_URL", :string, "ecto://cklist:cklist@localhost/cklist_dev") <>
+          System.get_env("MIX_TEST_PARTITION", "")
 
-if config_env() == :prod do
-  database_url = env!("DATABASE_URL")
-  maybe_ipv6 = if env!("ECTO_IPV6", :boolean, false), do: [:inet6], else: []
+  :dev ->
+    config :cklist, Cklist.Repo,
+      url: env!("DATABASE_URL", :string, "ecto://cklist:cklist@localhost/cklist_dev")
 
-  config :cklist, Cklist.Repo,
-    # ssl: true,
-    url: database_url,
-    pool_size: env!("POOL_SIZE", :integer, 10),
-    socket_options: maybe_ipv6
+  :prod ->
+    database_url = env!("DATABASE_URL")
+    maybe_ipv6 = if env!("ECTO_IPV6", :boolean, false), do: [:inet6], else: []
 
-  # The secret key base is used to sign/encrypt cookies and other secrets.
-  # A default value is used in config/dev.exs and config/test.exs but you
-  # want to use a different value for prod and you most likely don't want
-  # to check this value into version control, so we use an environment
-  # variable instead.
-  secret_key_base =
-    env!("SECRET_KEY_BASE") ||
-      raise """
-      environment variable SECRET_KEY_BASE is missing.
-      You can generate one by calling: mix phx.gen.secret
-      """
+    config :cklist, Cklist.Repo,
+      # ssl: true,
+      url: database_url,
+      pool_size: env!("POOL_SIZE", :integer, 10),
+      socket_options: maybe_ipv6
 
-  config :cklist, :dns_cluster_query, env!("DNS_CLUSTER_QUERY", :string, nil)
+    # The secret key base is used to sign/encrypt cookies and other secrets.
+    # A default value is used in config/dev.exs and config/test.exs but you
+    # want to use a different value for prod and you most likely don't want
+    # to check this value into version control, so we use an environment
+    # variable instead.
+    secret_key_base =
+      env!("SECRET_KEY_BASE") ||
+        raise """
+        environment variable SECRET_KEY_BASE is missing.
+        You can generate one by calling: mix phx.gen.secret
+        """
 
-  config :cklist, CklistWeb.Endpoint,
-    url: [host: env!("HTTP_HOSTNAME", :string, "example.com"), port: 443, scheme: "https"],
-    http: [
-      # Enable IPv6 and bind on all interfaces.
-      # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
-      # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
-      # for details about using IPv6 vs IPv4 and loopback vs public addresses.
-      ip: {0, 0, 0, 0, 0, 0, 0, 0},
-      port: env!("HTTP_PORT", :integer, 4000)
-    ],
-    secret_key_base: secret_key_base
+    config :cklist, :dns_cluster_query, env!("DNS_CLUSTER_QUERY", :string, nil)
 
-  # ## SSL Support
-  #
-  # To get SSL working, you will need to add the `https` key
-  # to your endpoint configuration:
-  #
-  #     config :cklist, CklistWeb.Endpoint,
-  #       https: [
-  #         ...,
-  #         port: 443,
-  #         cipher_suite: :strong,
-  #         keyfile: env!("SOME_APP_SSL_KEY_PATH", :string),
-  #         certfile: env!("SOME_APP_SSL_CERT_PATH", :string)
-  #       ]
-  #
-  # The `cipher_suite` is set to `:strong` to support only the
-  # latest and more secure SSL ciphers. This means old browsers
-  # and clients may not be supported. You can set it to
-  # `:compatible` for wider support.
-  #
-  # `:keyfile` and `:certfile` expect an absolute path to the key
-  # and cert in disk or a relative path inside priv, for example
-  # "priv/ssl/server.key". For all supported SSL configuration
-  # options, see https://hexdocs.pm/plug/Plug.SSL.html#configure/1
-  #
-  # We also recommend setting `force_ssl` in your endpoint, ensuring
-  # no data is ever sent via http, always redirecting to https:
-  #
-  #     config :cklist, CklistWeb.Endpoint,
-  #       force_ssl: [hsts: true]
-  #
-  # Check `Plug.SSL` for all available options in `force_ssl`.
+    config :cklist, CklistWeb.Endpoint,
+      url: [host: env!("HTTP_HOSTNAME", :string, "example.com"), port: 443, scheme: "https"],
+      http: [
+        # Enable IPv6 and bind on all interfaces.
+        # Set it to  {0, 0, 0, 0, 0, 0, 0, 1} for local network only access.
+        # See the documentation on https://hexdocs.pm/plug_cowboy/Plug.Cowboy.html
+        # for details about using IPv6 vs IPv4 and loopback vs public addresses.
+        ip: {0, 0, 0, 0, 0, 0, 0, 0},
+        port: env!("HTTP_PORT", :integer, 4000)
+      ],
+      secret_key_base: secret_key_base
 
-  # ## Configuring the mailer
-  #
-  # In production you need to configure the mailer to use a different adapter.
-  # Also, you may need to configure the Swoosh API client of your choice if you
-  # are not using SMTP. Here is an example of the configuration:
-  #
-  #     config :cklist, Cklist.Mailer,
-  #       adapter: Swoosh.Adapters.Mailgun,
-  #       api_key: System.get_env("MAILGUN_API_KEY"),
-  #       domain: System.get_env("MAILGUN_DOMAIN")
-  #
-  # For this example you need include a HTTP client required by Swoosh API client.
-  # Swoosh supports Hackney and Finch out of the box:
-  #
-  #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
-  #
-  # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
-  #
-  if env!("SMTP", :boolean, false) do
-    config :cklist, CKList.Mailer,
-      adapter: Swoosh.Adapters.SMTP,
-      hostname: env!("SMTP_HOSTNAME"),
-      relay: env!("SMTP_HOST"),
-      username: env!("SMTP_USER"),
-      port: env!("SMTP_PORT"),
-      password: env!("SMTP_PASSWORD"),
-      tls: :always,
-      auth: :always,
-      retries: 5,
-      no_mx_lookups: false,
-      tls_options: [
-        verify: :verify_peer,
-        cacerts: :certifi.cacerts(),
-        server_name_indication: String.to_charlist(env!("SMTP_HOST")),
-        depth: 99
-      ]
-  end
+    # ## SSL Support
+    #
+    # To get SSL working, you will need to add the `https` key
+    # to your endpoint configuration:
+    #
+    #     config :cklist, CklistWeb.Endpoint,
+    #       https: [
+    #         ...,
+    #         port: 443,
+    #         cipher_suite: :strong,
+    #         keyfile: env!("SOME_APP_SSL_KEY_PATH", :string),
+    #         certfile: env!("SOME_APP_SSL_CERT_PATH", :string)
+    #       ]
+    #
+    # The `cipher_suite` is set to `:strong` to support only the
+    # latest and more secure SSL ciphers. This means old browsers
+    # and clients may not be supported. You can set it to
+    # `:compatible` for wider support.
+    #
+    # `:keyfile` and `:certfile` expect an absolute path to the key
+    # and cert in disk or a relative path inside priv, for example
+    # "priv/ssl/server.key". For all supported SSL configuration
+    # options, see https://hexdocs.pm/plug/Plug.SSL.html#configure/1
+    #
+    # We also recommend setting `force_ssl` in your endpoint, ensuring
+    # no data is ever sent via http, always redirecting to https:
+    #
+    #     config :cklist, CklistWeb.Endpoint,
+    #       force_ssl: [hsts: true]
+    #
+    # Check `Plug.SSL` for all available options in `force_ssl`.
+
+    # ## Configuring the mailer
+    #
+    # In production you need to configure the mailer to use a different adapter.
+    # Also, you may need to configure the Swoosh API client of your choice if you
+    # are not using SMTP. Here is an example of the configuration:
+    #
+    #     config :cklist, Cklist.Mailer,
+    #       adapter: Swoosh.Adapters.Mailgun,
+    #       api_key: System.get_env("MAILGUN_API_KEY"),
+    #       domain: System.get_env("MAILGUN_DOMAIN")
+    #
+    # For this example you need include a HTTP client required by Swoosh API client.
+    # Swoosh supports Hackney and Finch out of the box:
+    #
+    #     config :swoosh, :api_client, Swoosh.ApiClient.Hackney
+    #
+    # See https://hexdocs.pm/swoosh/Swoosh.html#module-installation for details.
+    #
+    if env!("SMTP", :boolean, false) do
+      config :cklist, CKList.Mailer,
+        adapter: Swoosh.Adapters.SMTP,
+        hostname: env!("SMTP_HOSTNAME"),
+        relay: env!("SMTP_HOST"),
+        username: env!("SMTP_USER"),
+        port: env!("SMTP_PORT"),
+        password: env!("SMTP_PASSWORD"),
+        tls: :always,
+        auth: :always,
+        retries: 5,
+        no_mx_lookups: false,
+        tls_options: [
+          verify: :verify_peer,
+          cacerts: :certifi.cacerts(),
+          server_name_indication: String.to_charlist(env!("SMTP_HOST")),
+          depth: 99
+        ]
+    end
 end

--- a/config/test.exs
+++ b/config/test.exs
@@ -9,10 +9,6 @@ config :bcrypt_elixir, :log_rounds, 1
 # to provide built-in test partitioning in CI environment.
 # Run `mix help test` for more information.
 config :cklist, Cklist.Repo,
-  username: "cklist",
-  password: "cklist",
-  hostname: "localhost",
-  database: "cklist_test#{System.get_env("MIX_TEST_PARTITION")}",
   pool: Ecto.Adapters.SQL.Sandbox,
   pool_size: 10
 

--- a/mix.exs
+++ b/mix.exs
@@ -56,6 +56,9 @@ defmodule Cklist.MixProject do
       {:ex_cldr_units, "~> 3.16.4"},
       {:ex_cldr_plugs, "~> 1.3.1"},
 
+      # configuration
+      {:dotenvy, "~> 0.8.0"},
+
       # dev dependencies
       {:credo, "~> 1.7.3", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,10 @@ defmodule Cklist.MixProject do
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      releases: [
+        overlays: ["envs/"]
+      ]
     ]
   end
 


### PR DESCRIPTION
Introduce Dotenvy for pulling in `.env`-style configurations

 This allows, for instance, overriding the databse config with a file in `envs/.env` with these contents:

      DATABASE_URL="ecto://postgres@localhost/cklist_dev"

Essentially any env var-based config value can now be ovverriden at runtime  with a `.env` file. This is useful for deployment as well, as it  prevents secrets from entering the codebase and not having to pollute the global env with vars.