### PR TITLE
Pin node version in ./tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 elixir 1.16.0 1.16.0-otp-26
 erlang 26.2.1
+nodejs 20.11.0


### PR DESCRIPTION
Parts of the project depend on Nodejs. Pin the nodejs version in .tool-version to 20.11.0, which corresponds to the current LTS version.