### PR TITLE
Put the Gettext module in `lib/cklist/`

### DIFF
--- a/lib/cklist/gettext.ex
+++ b/lib/cklist/gettext.ex
@@ -1,11 +1,11 @@
-defmodule CklistWeb.Gettext do
+defmodule Cklist.Gettext do
   @moduledoc """
   A module providing Internationalization with a gettext-based API.
 
   By using [Gettext](https://hexdocs.pm/gettext),
   your module gains a set of macros for translations, for example:
 
-      import CklistWeb.Gettext
+      import Cklist.Gettext
 
       # Simple translation
       gettext("Here is the string to translate")

--- a/lib/cklist_web.ex
+++ b/lib/cklist_web.ex
@@ -43,7 +43,7 @@ defmodule CklistWeb do
         layouts: [html: CklistWeb.Layouts]
 
       import Plug.Conn
-      import CklistWeb.Gettext
+      import Cklist.Gettext
 
       unquote(verified_routes())
     end
@@ -85,7 +85,7 @@ defmodule CklistWeb do
       import Phoenix.HTML
       # Core UI components and translation
       import CklistWeb.CoreComponents
-      import CklistWeb.Gettext
+      import Cklist.Gettext
 
       # Shortcut for generating JS commands
       alias Phoenix.LiveView.JS

--- a/lib/cklist_web/components/core_components.ex
+++ b/lib/cklist_web/components/core_components.ex
@@ -17,7 +17,7 @@ defmodule CklistWeb.CoreComponents do
   use Phoenix.Component
 
   alias Phoenix.LiveView.JS
-  import CklistWeb.Gettext
+  import Cklist.Gettext
 
   @doc """
   Renders a modal.
@@ -659,9 +659,9 @@ defmodule CklistWeb.CoreComponents do
     # with our gettext backend as first argument. Translations are
     # available in the errors.po file (as we use the "errors" domain).
     if count = opts[:count] do
-      Gettext.dngettext(CklistWeb.Gettext, "errors", msg, msg, count, opts)
+      Gettext.dngettext(Cklist.Gettext, "errors", msg, msg, count, opts)
     else
-      Gettext.dgettext(CklistWeb.Gettext, "errors", msg, opts)
+      Gettext.dgettext(Cklist.Gettext, "errors", msg, opts)
     end
   end
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,23 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new messages manually only if they're dynamic
+## messages that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+#
+msgid ""
+msgstr ""
+
+#: lib/cklist_web/components/core_components.ex:482
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""
+
+#: lib/cklist_web/components/core_components.ex:76
+#: lib/cklist_web/components/core_components.ex:130
+#, elixir-autogen, elixir-format
+msgid "close"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,23 @@
+## "msgid"s in this file come from POT (.pot) files.
+###
+### Do not add, change, or remove "msgid"s manually here as
+### they're tied to the ones in the corresponding POT file
+### (with the same domain).
+###
+### Use "mix gettext.extract --merge" or "mix gettext.merge"
+### to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: lib/cklist_web/components/core_components.ex:482
+#, elixir-autogen, elixir-format
+msgid "Actions"
+msgstr ""
+
+#: lib/cklist_web/components/core_components.ex:76
+#: lib/cklist_web/components/core_components.ex:130
+#, elixir-autogen, elixir-format
+msgid "close"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -7,7 +7,6 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""


### PR DESCRIPTION
Puts the Gettext module in the business logic dir and fixes references to it. Phoenix boilerplate puts it in Web, but this ends up creating dependencies in the business logic side wherever/whenever translations are needed. This addresses #8 