### PR TITLE
ci: fix deployment script

### DIFF
--- a/.github/workflows/release_deploy.yaml
+++ b/.github/workflows/release_deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-  pull_request:  # un-comment to debug deployments
+#  pull_request:  # un-comment to debug deployments
 
 jobs:
   deploy:

--- a/.github/workflows/release_deploy.yaml
+++ b/.github/workflows/release_deploy.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-#  pull_request:  # un-comment to debug deployments
+  pull_request:  # un-comment to debug deployments
 
 jobs:
   deploy:
@@ -52,13 +52,13 @@ jobs:
         with:
           switches: -az
           path: _build/prod/rel/cklist/
-          remote_path: ${{ secrets.DEPLOY_PATH_RELEASES }}/cklist-${{ steps.info.outputs.version }}${{ env.rc }}-${{ steps.info.outputs.git-hash }}/
+          remote_path: ${{ secrets.DEPLOY_PATH_RELEASES }}/cklist-${{ steps.info.outputs.version }}${{ env.rc }}${{ steps.info.outputs.git-hash }}/
           remote_host: ${{ secrets.DEPLOY_HOST }}
           remote_user: ${{ secrets.DEPLOY_USER }}
           remote_port: ${{ secrets.DEPLOY_PORT }}
           remote_key: ${{ secrets.DEPLOY_KEY }}
         env:
-          rc: ${{ github.event_name == 'push' && '' || 'rc' }}
+          rc: ${{ github.event_name == 'push' && '-' || 'rc-' }}
 
 
       - uses: webfactory/ssh-agent@v0.9.0

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Cklist.MixProject do
   def project do
     [
       app: :cklist,
-      version: "0.0.4",
+      version: "0.0.5",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# Description

The fake ternary operator doesn't work with empty string (`''`) because it's interpreted as 'false'. Thus, make sure both paths have at least one character.

## Checklist

Guess what, we use checklists too :wink:

- [x] I did a self-review of the proposed changes
- [ ] I commented my code, particularly in hard-to-understand areas: N/A
- [ ] I added automated tests for new functionality (if applicable): N/A
