### PR TITLE
ci: Allow manual deployments for testing

### DIFF
--- a/.github/workflows/release_deploy.yaml
+++ b/.github/workflows/release_deploy.yaml
@@ -1,10 +1,12 @@
 name: Deploy release
 
 on:
+  # useful for (manually) deploying test/draft releases
+  workflow_dispatch:
+
   push:
     branches:
       - main
-#  pull_request:  # un-comment to debug deployments
 
 jobs:
   deploy:

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Cklist.MixProject do
   def project do
     [
       app: :cklist,
-      version: "0.0.6",
+      version: "0.0.7",
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# Description

This PR adds support for manually triggering test deployments. This was previously possible by un-commenting "on pull_request", but that's cumbersome and developers have to remember to properly comment it again. "on workflow_dispatch" allows to run the workflow manually when needed from the GitHub web interface.

## Checklist

Guess what, we use checklists too :wink:

- [x] I did a self-review of the proposed changes
- [x] I commented my code, particularly in hard-to-understand areas
- [ ] I added automated tests for new functionality (if applicable)
  N/A
